### PR TITLE
remove unwanted abspath

### DIFF
--- a/client.tf
+++ b/client.tf
@@ -7,7 +7,7 @@ resource "google_compute_instance" "client" {
 
   metadata = {
     ssh-keys = <<KEYS
-${var.ssh_user}:${file(abspath(var.public_key_path))}
+${var.ssh_user}:${file(var.public_key_path)}
 KEYS
   }
 


### PR DESCRIPTION
Abspath fails to correctly resolve ~/.ssh/id_rsa.pub in this context while file() would. Not much need for it. 