### PR TITLE
allow choosing hosts location

### DIFF
--- a/ansible-hosts-file.tf
+++ b/ansible-hosts-file.tf
@@ -17,5 +17,5 @@ resource "local_file" "hosts_ini" {
       tiered_storage_bucket_name = try(google_storage_bucket.tiered_storage[0].name, "")
     }
   )
-  filename = "${path.module}/hosts.ini"
+  filename = var.hosts_file
 }

--- a/vars.tf
+++ b/vars.tf
@@ -111,3 +111,9 @@ variable "allocate_brokers_public_ip" {
   type        = bool
   description = "whether to allocate brokers public ip addresses"
 }
+
+variable "hosts_file" {
+  default     = "hosts.ini"
+  description = "path and name for ansible hosts file generated as output of this module"
+  type        = string
+}


### PR DESCRIPTION
Currently the hosts file is always placed in the module directory. This is less than ideal in a CI environment